### PR TITLE
Typecheck all the code

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -53,7 +53,7 @@ if python --version 2>&1 | grep " 3" ; then
   # Verson of "python" binary is 3, do static type analysis. Mypy requires
   # Python 3, that's why we do this only on Python 3.
   pip install -r requirements-dev-py3.txt
-  mypy --py2 --ignore-missing-imports ./*.py ./*/*.py
+  mypy --py2 --ignore-missing-imports --check-untyped-defs ./*.py ./*/*.py
 fi
 
 # FIXME: We want to add to the coverage report, not overwrite it. How do we do

--- a/px/px_file.py
+++ b/px/px_file.py
@@ -6,6 +6,7 @@ import os
 import sys
 if sys.version_info.major >= 3:
     # For mypy PEP-484 static typing validation
+    from typing import List   # NOQA
     from typing import Tuple  # NOQA
 
 
@@ -13,8 +14,9 @@ class PxFile(object):
     def __init__(self):
         self._device_number = None
         self.pid = None
-        self.name = None
+        self.name = None  # type: str
         self.type = None
+        self.inode = None
         self.device = None
         self.access = None
 
@@ -172,7 +174,7 @@ def call_lsof():
 def lsof_to_files(lsof, file_types=None):
     pid = None
     file = None
-    files = []
+    files = []  # type: List[px_file.PxFile]
     for shard in lsof.split('\0'):
         if shard[0] == "\n":
             # Some shards start with newlines. Looks pretty when viewing the

--- a/px/px_file.py
+++ b/px/px_file.py
@@ -12,13 +12,14 @@ if sys.version_info.major >= 3:
 
 class PxFile(object):
     def __init__(self):
+        self.fd = None  # type: int
         self._device_number = None
-        self.pid = None
+        self.pid = None  # type: int
         self.name = None  # type: str
-        self.type = None
+        self.type = None  # type: str
         self.inode = None
         self.device = None
-        self.access = None
+        self.access = None  # type: str
 
     def __repr__(self):
         # The point of implementing this method is to make the py.test output
@@ -174,7 +175,7 @@ def call_lsof():
 def lsof_to_files(lsof, file_types=None):
     pid = None
     file = None
-    files = []  # type: List[px_file.PxFile]
+    files = []  # type: List[PxFile]
     for shard in lsof.split('\0'):
         if shard[0] == "\n":
             # Some shards start with newlines. Looks pretty when viewing the

--- a/px/px_ipc_map.py
+++ b/px/px_ipc_map.py
@@ -205,6 +205,11 @@ def create_fake_process(pid=None, name=None):
         name = "PID " + str(pid)
 
     class FakeProcess(object):
+        def __init__(self):
+            self.name = None
+            self.lowercase_command = None
+            self.pid = None
+
         def __repr__(self):
             return self.name
 

--- a/px/px_load.py
+++ b/px/px_load.py
@@ -48,7 +48,7 @@ def levels_to_graph(levels):
     unicodify = chr
     try:
         # Python 2
-        unicodify = unichr
+        unicodify = unichr  # type: ignore
     except NameError:
         # Python 3
         pass

--- a/px/px_loginhistory.py
+++ b/px/px_loginhistory.py
@@ -180,11 +180,11 @@ def _to_timestamp(string, now):
 def _to_timedelta(string):
     match = TIMEDELTA_RE.match(string)
 
-    days = match.group(2)
-    if days is None:
+    matched_days = match.group(2)
+    if matched_days is None:
         days = 0
     else:
-        days = int(days)
+        days = int(matched_days)
 
     hours = int(match.group(3))
 

--- a/px/px_process.py
+++ b/px/px_process.py
@@ -8,6 +8,12 @@ import dateutil.tz
 from . import px_commandline
 
 
+import sys
+if sys.version_info.major >= 3:
+    # For mypy PEP-484 static typing validation
+    from typing import MutableSet  # NOQA
+
+
 # Match + group: " 77082 1 Mon Mar  7 09:33:11 2016  netbios    0:00.08  0.0 /usr/sbin/netbiosd hej"
 PS_LINE = re.compile(
     " *([0-9]+) +([0-9]+) +([A-Za-z0-9: ]+) +([^ ]+) +([-0-9.:]+) +([0-9.]+) +(.*)")
@@ -47,6 +53,8 @@ class PxProcess(object):
 
         # Setting the CPU time like this implicitly recomputes the score
         self.set_cpu_time_seconds(process_builder.cpu_time)
+
+        self.children = None  # type: MutableSet[PxProcess]
 
     def __repr__(self):
         # I guess this is really what __str__ should be doing, but the point of
@@ -131,7 +139,14 @@ class PxProcess(object):
 
 
 class PxProcessBuilder(object):
-    pass
+    def __init__(self):
+        self.cmdline = None   # type: str
+        self.pid = None       # type: int
+        self.ppid = None      # type: int
+        self.start_time_string = None  # type: str
+        self.username = None  # type: str
+        self.cpu_time = None  # type: float
+        self.memory_percent = None  # type: float
 
 
 def call_ps():
@@ -148,6 +163,7 @@ def call_ps():
 
 
 def parse_time(timestring):
+    # type: (str) -> float
     """Convert a CPU time string returned by ps to a number of seconds"""
 
     match = CPUTIME_OSX.match(timestring)

--- a/px/px_processinfo.py
+++ b/px/px_processinfo.py
@@ -101,26 +101,26 @@ def get_closest_starts(process, all_processes):
     All processes started within 1s of the base process are returned, or the
     five closest if not at least five were that close.
     """
-    closest = set()
     by_temporal_vicinity = sorted(
         all_processes,
         key=lambda p: abs(p.age_seconds - process.age_seconds))
 
+    closest_raw = set()
     for close in by_temporal_vicinity:
         delta_seconds = abs(close.age_seconds - process.age_seconds)
 
         if delta_seconds <= 1:
-            closest.add(close)
+            closest_raw.add(close)
             continue
 
         # "5" is arbitrarily chosen, look at the printouts to see if it needs tuning
-        if len(closest) > 5:
+        if len(closest_raw) > 5:
             break
 
-        closest.add(close)
+        closest_raw.add(close)
 
     # Remove ourselves from the closest processes list
-    closest = filter(lambda p: p is not process, closest)
+    closest = filter(lambda p: p is not process, closest_raw)
 
     # Sort closest processes by age, command and PID in that order
     closest = sorted(closest, key=operator.attrgetter('command', 'pid'))

--- a/px/px_top.py
+++ b/px/px_top.py
@@ -131,7 +131,7 @@ def writebytes(bytestring):
         sys.stdout.write(bytestring)
     else:
         # http://stackoverflow.com/a/908440/473672
-        sys.stdout.buffer.write(bytestring)
+        sys.stdout.buffer.write(bytestring)  # type: ignore
 
 
 def clear_screen():

--- a/px/px_top.py
+++ b/px/px_top.py
@@ -72,8 +72,8 @@ def read_select(fds, timeout_seconds):
     while True:
         try:
             return select.select(fds, [], [], timeout_seconds)[0]
-        except select.error as ex:
-            if ex[0] == errno.EINTR:
+        except OSError as ex:
+            if ex.errno == errno.EINTR:
                 # EINTR happens when the terminal window is resized by the user,
                 # just try again.
                 continue

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,7 @@ function do-tests() {
     # Verson of "python" binary is 3, do static type analysis. Mypy requires
     # Python 3, that's why we do this only on Python 3.
     pip install -r requirements-dev-py3.txt
-    mypy --py2 --ignore-missing-imports ./*.py ./*/*.py
+    mypy --py2 --ignore-missing-imports --check-untyped-defs ./*.py ./*/*.py
   fi
 
   # Run tests

--- a/tests/benchmark_ipcmap.py
+++ b/tests/benchmark_ipcmap.py
@@ -19,12 +19,18 @@ import testutils
 from px import px_file
 from px import px_ipc_map
 
+import sys
+if sys.version_info.major >= 3:
+    # For mypy PEP-484 static typing validation
+    from typing import MutableMapping  # NOQA
+
+
 # For how long should we do the benchmarking run (in seconds)
 DURATION_S = 30
 
 
 def get_most_common_pid(files):
-    counts = {}
+    counts = {}  # type: MutableMapping[int, int]
     for file in files:
         pid = file.pid
         if pid not in counts:

--- a/tests/px_process_test.py
+++ b/tests/px_process_test.py
@@ -6,6 +6,11 @@ import pytest
 from px import px_process
 import testutils
 
+import sys
+if sys.version_info.major >= 3:
+    # For mypy PEP-484 static typing validation
+    from typing import MutableSet  # NOQA
+
 
 def test_create_process():
     process_builder = px_process.PxProcessBuilder()
@@ -134,7 +139,7 @@ def _test_get_all():
     assert 1 in pids
 
     # Assert that all contains no duplicate PIDs
-    seen_pids = set()
+    seen_pids = set()  # type: MutableSet[int]
     for process in all:
         pid = process.pid
         assert pid not in seen_pids

--- a/tests/px_processinfo_test.py
+++ b/tests/px_processinfo_test.py
@@ -3,6 +3,11 @@ from px import px_processinfo
 
 import testutils
 
+import sys
+if sys.version_info.major >= 3:
+    # For mypy PEP-484 static typing validation
+    from typing import List  # NOQA
+
 
 def test_to_relative_start_string():
     base = testutils.create_process(pid=100, timestring="Mon Mar 7 09:33:11 2016")
@@ -91,7 +96,7 @@ def test_print_starttime():
 
 
 def test_print_process_subtree():
-    lines = []
+    lines = []  # type: List[str]
 
     child_proc = testutils.create_process(pid=2, commandline="child")
     child_proc.children = []

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -7,6 +7,13 @@ from px import px_ipc_map
 import dateutil.tz
 import dateutil.parser
 
+
+import sys
+if sys.version_info.major >= 3:
+    # For mypy PEP-484 static typing validation
+    from typing import MutableMapping  # NOQA
+
+
 # An example time string that can be produced by ps
 TIMESTRING = "Mon Mar 7 09:33:11 2016"
 TIME = dateutil.parser.parse(TIMESTRING).replace(tzinfo=dateutil.tz.tzlocal())
@@ -41,7 +48,7 @@ def create_process(pid=47536, ppid=1234,
 
 def create_ipc_map(pid, all_files):
     """Wrapper around IpcMap() so that we can test it"""
-    pid2process = {}
+    pid2process = {}  # type: MutableMapping[int, px_process.PxProcess]
     for file in all_files:
         if file.pid in pid2process:
             continue


### PR DESCRIPTION
With this change we enable `mypy`'s `--check-untyped-defs` flag, meaning that all code, even unannotated code is now type checked.

This makes me more comfortable with modifying `px_ipcmap.py` as part of working on #35.