### PR TITLE
Run only tests that need running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.coverage
 /.mypy_cache/
 /.pytest_cache/
+/.pytest-avoidance/
 
 # See: https://packaging.python.org/distributing/#uploading-your-project-to-pypi
 /.pypirc

--- a/ci.sh
+++ b/ci.sh
@@ -57,6 +57,8 @@ if [ ! -d "${ENVDIR}" ]; then
   # shellcheck source=/dev/null
   . "${ENVDIR}"/bin/activate
 
+  pip install -r requirements.txt
+
   # Fix tools versions
   pip install -r requirements-dev.txt
 
@@ -82,9 +84,7 @@ fi
 
 flake8 px tests scripts setup.py
 
-# FIXME: We want to add to the coverage report, not overwrite it. How do we do
-# that?
-PYTEST_ADDOPTS="--cov=px -v --durations=10" ./setup.py test
+./scripts/run-tests.py
 
 # Create px wheel...
 rm -rf dist "${ENVDIR}"/pxpx-*.whl build/lib/px

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flake8 == 3.5.0
 wheel == 0.31.1
 setuptools == 39.2.0
 pytest == 4.2.0
+coverage == 4.5.2

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""
+Run tests using pytest but only ones that need rerunning
+"""
+
+import pytest
+
+# FIXME: Figure these out dynamically
+TEST_FILE = "tests/px_file_test.py"
+TEST_NAME = "test_listen_name"  # NOTE: The slow one is "test_get_all"
+
+pytest.main(args=[TEST_FILE + "::" + TEST_NAME])

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -63,10 +63,8 @@ def get_depsfile_name(test_file, test_name):
 
     cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, test_file)
 
-    print("Cachedir name: " + cachedir)
     mkdir_p(cachedir)
     depsfile_name = os.path.join(cachedir, test_name + ".deps")
-    print("Depsfile name: " + depsfile_name)
 
     return depsfile_name
 
@@ -145,7 +143,6 @@ for testfile_name in glob.glob("tests/*_test.py"):
             if not matches:
                 continue
             test_name = matches.group(1)
-            print(test_name)
             exitcode = maybe_run_test(testfile_name, test_name)
             if exitcode != 0:
                 something_failed = True

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -28,6 +28,20 @@ def mkdir_p(path):
             raise
 
 
+def get_depsfile_name(test_file, test_name):
+    # Dependencies file naming scheme:
+    # .pytest-avoidance/<VM-identifier>/<path to .py file>/testname.deps
+
+    # FIXME: Ensure test_file path doesn't start with "/", or CACHEROOT and VM_IDENTIFIER
+    # will be dropped by os.path.join()
+    cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, test_file)
+
+    print ("Cachedir name: " + cachedir)
+    mkdir_p(cachedir)
+    depsfile_name = os.path.join(cachedir, test_name + ".deps")
+    print ("Depsfile name: " + depsfile_name)
+
+
 def run_test(test_file, test_name):
     # FIXME: Check with cache, do we really need to run this?
 
@@ -42,21 +56,7 @@ def run_test(test_file, test_name):
     cov.stop()
     coverage_data = cov.get_data()
 
-    # Store the file-timestamps list into a file
-    #
-    # File naming scheme:
-    # .pytest-avoidance/<VM-identifier>/<path to .py file>/testname.deps
-
-    # FIXME: Ensure test_file path doesn't start with "/", or CACHEROOT and VM_IDENTIFIER
-    # will be dropped by os.path.join()
-    cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, test_file)
-
-    print ("Cachedir name: " + cachedir)
-    mkdir_p(cachedir)
-    depsfile_name = os.path.join(cachedir, test_name + ".deps")
-    print ("Depsfile name: " + depsfile_name)
-    # Now write our stuff into depsfile
-    with open(depsfile_name, "w") as depsfile:
+    with open(get_depsfile_name(test_file, test_name), "w") as depsfile:
         for file in coverage_data.measured_files():
             epoch_timestamp = os.path.getmtime(file)
             datetime_timestamp = datetime.datetime.fromtimestamp(epoch_timestamp, dateutil.tz.tzlocal())

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -4,6 +4,7 @@ Run tests using pytest but only ones that need rerunning
 """
 
 import os
+import sys
 
 import errno
 import pytest
@@ -11,8 +12,15 @@ import coverage
 
 CACHEROOT = '.pytest-avoidance'
 
-# FIXME: This should be python-<version>-<hash-of-the-python-binary>
-VM_IDENTIFIER = 'python-1.2.3'
+
+def get_vm_identifier():
+    (major, minor, micro, *_) = sys.version_info
+
+    # FIXME: This should be python-<version>-<hash-of-the-python-binary-and-its-path>
+    return "python-{}.{}.{}".format(major, minor, micro)
+
+
+VM_IDENTIFIER = get_vm_identifier()
 
 
 # From: https://stackoverflow.com/a/600612/473672

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -5,27 +5,60 @@ Run tests using pytest but only ones that need rerunning
 
 import os
 
+import errno
 import pytest
 import coverage
 import datetime
 import dateutil.tz
 
+CACHEROOT = '.pytest-avoidance'
+
+# FIXME: This should be python-<version>-<hash-of-the-python-binary>
+VM_IDENTIFIER = 'python-1.2.3'
+
 # FIXME: Figure these out dynamically
 TEST_FILE = "tests/px_file_test.py"
 TEST_NAME = "test_listen_name"  # NOTE: The slow one is "test_get_all"
 
+
+# From: https://stackoverflow.com/a/600612/473672
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
 # Run test and collect coverage data
 cov = coverage.Coverage()
 cov.start()
-pytest.main(args=[TEST_FILE + "::" + TEST_NAME])
+exitcode = pytest.main(args=[TEST_FILE + "::" + TEST_NAME])
+if exitcode is not 0:
+    # FIXME: Remove any cached data for this test and run the next one instead
+    pass
+
 cov.stop()
 coverage_data = cov.get_data()
 
-# FIXME: If the test failed, drop it from the cache
+# Store the file-timestamps list into a file
+#
+# File naming scheme:
+# .pytest-avoidance/<VM-identifier>/<path to .py file>/testname.deps
 
-# Print covered files
-for file in coverage_data.measured_files():
-    epoch_timestamp = os.path.getmtime(file)
-    datetime_timestamp = datetime.datetime.fromtimestamp(epoch_timestamp, dateutil.tz.tzlocal())
+# FIXME: Ensure TEST_FILE path doesn't start with "/", or CACHEROOT and VM_IDENTIFIER
+# will be dropped by os.path.join()
+cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, TEST_FILE)
 
-    print(datetime_timestamp.isoformat(), " ", file)
+print ("Cachedir name: " + cachedir)
+mkdir_p(cachedir)
+depsfile_name = os.path.join(cachedir, TEST_NAME + ".deps")
+print ("Depsfile name: " + depsfile_name)
+# Now write our stuff into depsfile
+with open(depsfile_name, "w") as depsfile:
+    for file in coverage_data.measured_files():
+        epoch_timestamp = os.path.getmtime(file)
+        datetime_timestamp = datetime.datetime.fromtimestamp(epoch_timestamp, dateutil.tz.tzlocal())
+        depsfile.write("%s %s\n" % (datetime_timestamp.isoformat(), file))

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -51,8 +51,14 @@ def get_depsfile_name(test_file, test_name):
     # Dependencies file naming scheme:
     # .pytest-avoidance/<VM-identifier>/<path to .py file>/testname.deps
 
-    # FIXME: Ensure test_file path doesn't start with "/", or CACHEROOT and VM_IDENTIFIER
-    # will be dropped by os.path.join()
+    test_file = os.path.abspath(test_file)
+    if test_file[1] == ':':
+        # Somebody on a Windows box, please test this
+        test_file = test_file.replace(':', '/', 1)
+    if test_file[0] == '/':
+        # Starting the path with '/' would mess up os.path.join()
+        test_file = test_file[1:]
+
     cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, test_file)
 
     print("Cachedir name: " + cachedir)
@@ -128,4 +134,5 @@ def maybe_run_test(test_file, test_name):
 
 
 # FIXME: Discover these like pytest does
-maybe_run_test("tests/px_file_test.py", "test_listen_name")
+exitcode = maybe_run_test("tests/px_file_test.py", "test_listen_name")
+sys.exit(exitcode)

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -43,8 +43,6 @@ def get_depsfile_name(test_file, test_name):
 
 
 def run_test(test_file, test_name):
-    # FIXME: Check with cache, do we really need to run this?
-
     # Run test and collect coverage data
     cov = coverage.Coverage()
     cov.start()
@@ -80,7 +78,6 @@ def has_cached_success(test_file, test_name):
 
             file_timestamp = os.path.getmtime(filename)
 
-            # FIXME: Is some wiggle room needed in this comparison?
             if file_timestamp > cache_timestamp:
                 # Dependency has changed
                 # FIXME: Remove this cache entry here?

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -135,7 +135,7 @@ def maybe_run_test(test_file, test_name):
         return run_test(test_file, test_name)
 
 
-# FIXME: Discover these like pytest does
+# Discover these like pytest does
 something_failed = False
 TEST_FUNCTION = re.compile("^def (test_[^)]+)\(")
 for testfile_name in glob.glob("tests/*_test.py"):
@@ -150,7 +150,10 @@ for testfile_name in glob.glob("tests/*_test.py"):
             if exitcode != 0:
                 something_failed = True
 
+print("")
 if something_failed:
+    print("There were failures!")
     sys.exit(1)
 else:
+    print("All tests passed!")
     sys.exit(0)

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -3,8 +3,12 @@
 Run tests using pytest but only ones that need rerunning
 """
 
+import os
+
 import pytest
 import coverage
+import datetime
+import dateutil.tz
 
 # FIXME: Figure these out dynamically
 TEST_FILE = "tests/px_file_test.py"
@@ -17,6 +21,11 @@ pytest.main(args=[TEST_FILE + "::" + TEST_NAME])
 cov.stop()
 coverage_data = cov.get_data()
 
+# FIXME: If the test failed, drop it from the cache
+
 # Print covered files
 for file in coverage_data.measured_files():
-    print(file)
+    epoch_timestamp = os.path.getmtime(file)
+    datetime_timestamp = datetime.datetime.fromtimestamp(epoch_timestamp, dateutil.tz.tzlocal())
+
+    print(datetime_timestamp.isoformat(), " ", file)

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import glob
+import time
 import errno
 import hashlib
 
@@ -134,7 +135,9 @@ def maybe_run_test(test_file, test_name):
 
 
 # Discover these like pytest does
-something_failed = False
+passcount = 0
+failcount = 0
+t0 = time.time()
 TEST_FUNCTION = re.compile("^def (test_[^)]+)\(")
 for testfile_name in glob.glob("tests/*_test.py"):
     with open(testfile_name, 'r') as testfile:
@@ -144,11 +147,20 @@ for testfile_name in glob.glob("tests/*_test.py"):
                 continue
             test_name = matches.group(1)
             exitcode = maybe_run_test(testfile_name, test_name)
-            if exitcode != 0:
-                something_failed = True
+            if exitcode is 0:
+                passcount += 1
+            else:
+                failcount += 1
+t1 = time.time()
+dt = t1 - t0
 
 print("")
-if something_failed:
+print("{} tests run in {}s".format(passcount + failcount, int(dt)))
+print("PASS: {}".format(passcount))
+print("FAIL: {}".format(failcount))
+
+print("")
+if failcount > 0:
     print("There were failures!")
     sys.exit(1)
 else:

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -4,9 +4,19 @@ Run tests using pytest but only ones that need rerunning
 """
 
 import pytest
+import coverage
 
 # FIXME: Figure these out dynamically
 TEST_FILE = "tests/px_file_test.py"
 TEST_NAME = "test_listen_name"  # NOTE: The slow one is "test_get_all"
 
+# Run test and collect coverage data
+cov = coverage.Coverage()
+cov.start()
 pytest.main(args=[TEST_FILE + "::" + TEST_NAME])
+cov.stop()
+coverage_data = cov.get_data()
+
+# Print covered files
+for file in coverage_data.measured_files():
+    print(file)

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -16,10 +16,6 @@ CACHEROOT = '.pytest-avoidance'
 # FIXME: This should be python-<version>-<hash-of-the-python-binary>
 VM_IDENTIFIER = 'python-1.2.3'
 
-# FIXME: Figure these out dynamically
-TEST_FILE = "tests/px_file_test.py"
-TEST_NAME = "test_listen_name"  # NOTE: The slow one is "test_get_all"
-
 
 # From: https://stackoverflow.com/a/600612/473672
 def mkdir_p(path):
@@ -32,33 +28,40 @@ def mkdir_p(path):
             raise
 
 
-# Run test and collect coverage data
-cov = coverage.Coverage()
-cov.start()
-exitcode = pytest.main(args=[TEST_FILE + "::" + TEST_NAME])
-if exitcode is not 0:
-    # FIXME: Remove any cached data for this test and run the next one instead
-    pass
+def run_test(test_file, test_name):
+    # FIXME: Check with cache, do we really need to run this?
 
-cov.stop()
-coverage_data = cov.get_data()
+    # Run test and collect coverage data
+    cov = coverage.Coverage()
+    cov.start()
+    exitcode = pytest.main(args=[test_file + "::" + test_name])
+    if exitcode is not 0:
+        # FIXME: Remove any cached data for this test and run the next one instead
+        pass
 
-# Store the file-timestamps list into a file
-#
-# File naming scheme:
-# .pytest-avoidance/<VM-identifier>/<path to .py file>/testname.deps
+    cov.stop()
+    coverage_data = cov.get_data()
 
-# FIXME: Ensure TEST_FILE path doesn't start with "/", or CACHEROOT and VM_IDENTIFIER
-# will be dropped by os.path.join()
-cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, TEST_FILE)
+    # Store the file-timestamps list into a file
+    #
+    # File naming scheme:
+    # .pytest-avoidance/<VM-identifier>/<path to .py file>/testname.deps
 
-print ("Cachedir name: " + cachedir)
-mkdir_p(cachedir)
-depsfile_name = os.path.join(cachedir, TEST_NAME + ".deps")
-print ("Depsfile name: " + depsfile_name)
-# Now write our stuff into depsfile
-with open(depsfile_name, "w") as depsfile:
-    for file in coverage_data.measured_files():
-        epoch_timestamp = os.path.getmtime(file)
-        datetime_timestamp = datetime.datetime.fromtimestamp(epoch_timestamp, dateutil.tz.tzlocal())
-        depsfile.write("%s %s\n" % (datetime_timestamp.isoformat(), file))
+    # FIXME: Ensure test_file path doesn't start with "/", or CACHEROOT and VM_IDENTIFIER
+    # will be dropped by os.path.join()
+    cachedir = os.path.join(CACHEROOT, VM_IDENTIFIER, test_file)
+
+    print ("Cachedir name: " + cachedir)
+    mkdir_p(cachedir)
+    depsfile_name = os.path.join(cachedir, test_name + ".deps")
+    print ("Depsfile name: " + depsfile_name)
+    # Now write our stuff into depsfile
+    with open(depsfile_name, "w") as depsfile:
+        for file in coverage_data.measured_files():
+            epoch_timestamp = os.path.getmtime(file)
+            datetime_timestamp = datetime.datetime.fromtimestamp(epoch_timestamp, dateutil.tz.tzlocal())
+            depsfile.write("%s %s\n" % (datetime_timestamp.isoformat(), file))
+
+
+# FIXME: Discover these like pytest does
+run_test("tests/px_file_test.py", "test_listen_name")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,2 @@
-[aliases]
-test=pytest
-
 [flake8]
 max-line-length = 100
-
-[tool:pytest]
-testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -50,15 +50,6 @@ setup(
     # See: http://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
     zip_safe=True,
 
-    setup_requires=[
-        'pytest-runner',
-        'pytest-cov',
-    ],
-
-    tests_require=[
-        'pytest',
-    ],
-
     entry_points={
         'console_scripts': [
             'px = px.px:main',


### PR DESCRIPTION
Those would be tests that exercise code that have changed since last
run.

Before this change, ci.sh took 44s on my laptop.

With this change in place, ci.sh takes between 27s and 53s depending
on how many test results can be taken from the cache.

This helps local development (where the cache will mostly be warm)
more than remove CI runs (where the cache will be cold).