### PR TITLE
Fix macOS CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ minversion = 3.8.0
 
 mypy_version = 0.971
 pylint_version = 2.13.9
-pytest_version = 5.4.1
+pytest_version = 7.1.3
 
 envlist=
     version.py


### PR DESCRIPTION
Failed run:
https://github.com/walles/px/runs/8282454080?check_suite_focus=true

Solution from here:
https://stackoverflow.com/a/69569206/473672

This still passed for me locally though, and on Linux CI, but it failed
on macOS CI. Let's see if bumping helps!
