### PR TITLE
Fix CI problems

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install tox in our virtualenv
         run: |
           . ./env/bin/activate
-          pip install tox
+          pip install tox==4.0.9
       - name: Run tox in our virtualenv
         run: |
           . ./env/bin/activate

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install tox in our virtualenv
         run: |
           . ./env/bin/activate
-          pip install tox
+          pip install tox==4.0.9
       - name: Run tox in our virtualenv
         run: |
           . ./env/bin/activate

--- a/px/px_pager.py
+++ b/px/px_pager.py
@@ -126,7 +126,12 @@ def page_process_info(
     info_thread = threading.Thread(
         target=_pump_info_to_fd, args=(pager_stdin, process, processes)
     )
-    info_thread.setDaemon(True)  # Terminating ptop while this is running is fine
+
+    # Terminating ptop while this is running is fine. This is deprecated since
+    # Python 3.10, but we want to support older Pythons as well so let's keep it
+    # this way for now.
+    info_thread.setDaemon(True)  # pylint: disable=deprecated-method
+
     info_thread.start()
 
     pagerExitcode = pager.wait()

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ envlist=
 [testenv]
 skip_install = true
 basepython = python3
+allowlist_externals = /bin/bash
 
 [testenv:version.py]
 commands =
@@ -67,6 +68,7 @@ commands =
     /bin/bash -c 'shellcheck ./*.sh ./*/*.sh'
 
 [testenv:installtest]
+allowlist_externals = {toxinidir}/tests/installtest.sh
 commands =
     {toxinidir}/tests/installtest.sh
 
@@ -105,7 +107,9 @@ commands =
 [testenv:test-wheel]
 # Test installing using pip
 depends = version.py black
-allowlist_externals = /bin/rm
+allowlist_externals =
+    /bin/bash
+    /bin/rm
 deps =
     setuptools == 44.1.1
     wheel == 0.35.1

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ commands =
 depends = package
 commands =
     # Verify we have the correct shebang
-    /bin/bash -c 'head -n1 {toxinidir}/px.pex | grep -Eq "^#!/usr/bin/env python3$"'
+    /bin/bash -c 'head -n1 {toxinidir}/px.pex | grep -Eq "^\#!/usr/bin/env python3$"'
     # Test that there are no natively compiled dependencies. They make
     # distribution a lot harder. If this triggers, fix your dependencies!
     /bin/bash -c '! unzip -qq -l "{toxinidir}/px.pex" "*.so"'


### PR DESCRIPTION
- Fix the tox version
- Add missing allowlist_externals
- Accept using deprecated setDaemon()
- Add a now-needed escape
