### PR TITLE
Parse command out of most Guile command lines

### DIFF
--- a/px/px_commandline.py
+++ b/px/px_commandline.py
@@ -358,7 +358,7 @@ def get_guile_command(commandline: str) -> Optional[str]:
         or array[1].startswith("--listen=")
         or array[1].startswith("--use-srfi=")
     ):
-        if len(array) > 1 and array[1] in IGNORE_ARGFUL_SWITCHES:
+        if array[1] in IGNORE_ARGFUL_SWITCHES:
             if array[1] == "-l" and len(array) > 2:
                 # That guile script will be executed first
                 return array[2]
@@ -367,9 +367,8 @@ def get_guile_command(commandline: str) -> Optional[str]:
         else:
             del array[1]
 
-    guile = os.path.basename(array[0])
     if len(array) == 1:
-        return guile
+        return None
 
     if array[1].startswith("-"):
         return None

--- a/px/px_commandline.py
+++ b/px/px_commandline.py
@@ -352,11 +352,11 @@ def get_guile_command(commandline: str) -> Optional[str]:
         "-e",
     ]
     while len(array) > 1 and (
-      array[1] in IGNORE_SWITCHES
-      or array[1] in IGNORE_ARGFUL_SWITCHES
-      or array[1].startswith("--language=")
-      or array[1].startswith("--listen=")
-      or array[1].startswith("--use-srfi=")
+        array[1] in IGNORE_SWITCHES
+        or array[1] in IGNORE_ARGFUL_SWITCHES
+        or array[1].startswith("--language=")
+        or array[1].startswith("--listen=")
+        or array[1].startswith("--use-srfi=")
     ):
         if len(array) > 1 and array[1] in IGNORE_ARGFUL_SWITCHES:
             if array[1] == "-l" and len(array) > 2:

--- a/px/px_commandline.py
+++ b/px/px_commandline.py
@@ -204,6 +204,9 @@ def get_command(commandline: str) -> str:
     if command.startswith("python") or command == "Python":
         return faillog(commandline, get_python_command(commandline))
 
+    if command.startswith("guile"):
+        return faillog(commandline, get_guile_command(commandline))
+
     if command == "Electron":
         clarified = try_clarify_electron(commandline)
         if clarified:
@@ -317,6 +320,61 @@ def get_command(commandline: str) -> str:
             command = command_suggestion
 
     return app_name_prefix + command
+
+
+def get_guile_command(commandline: str) -> Optional[str]:
+    array = to_array(commandline)
+    array = list(filter(lambda s: s, array))
+
+    # Ignore some switches.
+    IGNORE_SWITCHES = [
+        "-s",
+        "--listen",
+        "-ds",
+        "--debug",
+        "--no-debug",
+        "--auto-compile",
+        "--fresh-auto-compile",
+        "--no-auto-compile",
+        "-q",
+        "--r6rs",
+        "--r7rs",
+        "-h",
+        "--help",
+        "-v",
+        "--version",
+    ]
+    IGNORE_ARGFUL_SWITCHES = [
+        "-L",
+        "-C",
+        "-x",
+        "-l",
+        "-e",
+    ]
+    while len(array) > 1 and (
+      array[1] in IGNORE_SWITCHES
+      or array[1] in IGNORE_ARGFUL_SWITCHES
+      or array[1].startswith("--language=")
+      or array[1].startswith("--listen=")
+      or array[1].startswith("--use-srfi=")
+    ):
+        if len(array) > 1 and array[1] in IGNORE_ARGFUL_SWITCHES:
+            if array[1] == "-l" and len(array) > 2:
+                # That guile script will be executed first
+                return array[2]
+            else:
+                del array[1:3]
+        else:
+            del array[1]
+
+    guile = os.path.basename(array[0])
+    if len(array) == 1:
+        return guile
+
+    if array[1].startswith("-"):
+        return None
+
+    return os.path.basename(array[1])
 
 
 def get_python_command(commandline: str) -> Optional[str]:

--- a/tests/px_commandline_test.py
+++ b/tests/px_commandline_test.py
@@ -191,6 +191,31 @@ def test_get_command_python():
     assert px_commandline.get_command("python    ") == "python"
 
 
+def test_get_command_guile():
+    assert px_commandline.get_command("guile") == "guile"
+    assert px_commandline.get_command("guile --help") == "guile"
+
+    assert px_commandline.get_command("guile apa.scm") == "apa.scm"
+    assert px_commandline.get_command("guile /usr/bin/apa.scm") == "apa.scm"
+    assert px_commandline.get_command("guile /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile -L foo /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile -L foo -C bar /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile -x ex /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile -l bar /usr/bin/hej") == "bar"
+    assert px_commandline.get_command("guile -e quux /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --language=ecmascript /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --debug /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --no-debug /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --auto-compile /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --fresh-auto-compile /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --no-auto-compile /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --listen /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile -q /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --use-srfi=2,13,14 /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --r6rs /usr/bin/hej") == "hej"
+    assert px_commandline.get_command("guile --r7rs /usr/bin/hej") == "hej"
+
+
 def test_get_command_aws():
     assert px_commandline.get_command("Python /usr/local/bin/aws") == "aws"
     assert px_commandline.get_command("python aws s3") == "aws s3"

--- a/tests/px_commandline_test.py
+++ b/tests/px_commandline_test.py
@@ -203,11 +203,15 @@ def test_get_command_guile():
     assert px_commandline.get_command("guile -x ex /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile -l bar /usr/bin/hej") == "bar"
     assert px_commandline.get_command("guile -e quux /usr/bin/hej") == "hej"
-    assert px_commandline.get_command("guile --language=ecmascript /usr/bin/hej") == "hej"
+    assert (
+        px_commandline.get_command("guile --language=ecmascript /usr/bin/hej") == "hej"
+    )
     assert px_commandline.get_command("guile --debug /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile --no-debug /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile --auto-compile /usr/bin/hej") == "hej"
-    assert px_commandline.get_command("guile --fresh-auto-compile /usr/bin/hej") == "hej"
+    assert (
+        px_commandline.get_command("guile --fresh-auto-compile /usr/bin/hej") == "hej"
+    )
     assert px_commandline.get_command("guile --no-auto-compile /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile --listen /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile -q /usr/bin/hej") == "hej"

--- a/tests/px_commandline_test.py
+++ b/tests/px_commandline_test.py
@@ -202,6 +202,8 @@ def test_get_command_guile():
     assert px_commandline.get_command("guile -L foo -C bar /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile -x ex /usr/bin/hej") == "hej"
     assert px_commandline.get_command("guile -l bar /usr/bin/hej") == "bar"
+    assert px_commandline.get_command("guile -l bar") == "bar"
+    assert px_commandline.get_command("guile -l") == "guile"
     assert px_commandline.get_command("guile -e quux /usr/bin/hej") == "hej"
     assert (
         px_commandline.get_command("guile --language=ecmascript /usr/bin/hej") == "hej"


### PR DESCRIPTION
px already has a special parser that finds out what the python script is instead of just saying "python" in the process list.

This adds a similar parser for fishing out GNU Guile script names.