### PR TITLE
Bump CI dependencies

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,7 +3,7 @@ name: Continuous Delivery
 env:
   # NOTE: This version must match between all .yml files in the
   # .github/workflows directory
-  TOX_VERSION: 4.0.9
+  TOX_VERSION: 4.24.2
 
 on:
   release:
@@ -45,7 +45,7 @@ jobs:
           git fetch --tags --force
           git describe --dirty
       - name: Cache .tox directory
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .tox
           key: ${{ runner.os }}-${{ hashFiles('tox.ini') }}

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -3,7 +3,7 @@ name: Linux CI
 env:
   # NOTE: This version must match between all .yml files in the
   # .github/workflows directory
-  TOX_VERSION: 4.0.9
+  TOX_VERSION: 4.24.2
 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
@@ -21,7 +21,7 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
   tox:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       # This is a regex:
       # https://github.com/tox-dev/tox/pull/990/files#diff-bfeb43314e311bd2d19d2b1ea565841101c8468f0df8cd3f86b4f199f06c0766
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0 # For getting tags from the repo
       - name: Cache .tox directory
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .tox
           key: ${{ runner.os }}-${{ hashFiles('tox.ini') }}

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -3,7 +3,7 @@ name: macOS CI
 env:
   # NOTE: This version must match between all .yml files in the
   # .github/workflows directory
-  TOX_VERSION: 4.0.9
+  TOX_VERSION: 4.24.2
 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
@@ -14,14 +14,14 @@ on:
 
 jobs:
   tox:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # For getting tags from the repo
       - name: Cache .tox directory
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .tox
           key: ${{ runner.os }}-${{ hashFiles('tox.ini') }}

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@
 # https://github.com/tox-dev/tox/pull/1202
 minversion = 3.8.0
 
-mypy_version = 1.11.2
-ruff_version = 0.6.5
-pytest_version = 8.2.2
-setuptools_version = 74.1.2
+mypy_version = 1.15.0
+ruff_version = 0.10.0
+pytest_version = 8.3.5
+setuptools_version = 76.0.0
 
 envlist=
     version.py
@@ -116,7 +116,7 @@ allowlist_externals =
     /bin/rm
 deps =
     setuptools == {[tox]setuptools_version}
-    build == 1.2.2
+    build == 1.2.2.post1
 commands =
     # clean up build/ and dist/ folders
     /bin/rm -rf build dist


### PR DESCRIPTION
Our macOS setup stopped existing and the runs just stalled.

This change will hopefully make that not happen again.